### PR TITLE
Add missing warning localization

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -59,6 +59,10 @@
   "HTBAH.Weapon": "Waffe",
   "HTBAH.Initiative": "Initiative",
 
+  "HTBAH.WarningOnlySkillsAllowed": "Hier können nur Fähigkeiten abgelegt werden.",
+  "HTBAH.WarningOnlyWeaponsAllowed": "Hier können nur Waffen abgelegt werden.",
+  "HTBAH.WarningWrongSkillSet": "Hier können nur {expected} Fähigkeiten abgelegt werden.",
+
   "HTBAH.HitPoints": "Lebenspunkte",
 
   "HTBAH.Inventory": "Inventar",  

--- a/lang/en.json
+++ b/lang/en.json
@@ -59,6 +59,10 @@
   "HTBAH.Weapon": "Weapon",
   "HTBAH.Initiative": "Initiative",
 
+  "HTBAH.WarningOnlySkillsAllowed": "Only skills may be dropped here.",
+  "HTBAH.WarningOnlyWeaponsAllowed": "Only weapons may be dropped here.",
+  "HTBAH.WarningWrongSkillSet": "You can only drop {expected} skills here.",
+
   "HTBAH.Names": "Names",
 
   "HTBAH.HitPoints": "Hitpoints",

--- a/module/helpers/drag-drop-handler.mjs
+++ b/module/helpers/drag-drop-handler.mjs
@@ -3,6 +3,30 @@ export class HowToBeAHeroDragDropHandler {
       this.sheet = sheet;
       this.actor = sheet.actor;
     }
+
+    /**
+     * Get or create the Item associated with provided drop data.
+     * If the dropped data references an Item not already owned by the actor,
+     * a new embedded Item will be created from the drop data.
+     * @param {object} data              The data object extracted from the drag event.
+     * @returns {Promise<Item|null>}     The resolved Item document or null on failure.
+     * @private
+     */
+    async _resolveDroppedItem(data) {
+      if (data.type !== "Item") return null;
+
+      // Resolve the dropped item from the provided data
+      let item = await Item.implementation.fromDropData(data);
+      if (!item) return null;
+
+      // If the item does not belong to this actor, create it as an embedded document
+      if (item.parent?.id !== this.actor.id) {
+        const [created] = await this.actor.createEmbeddedDocuments("Item", [item.toObject()]);
+        item = created;
+      }
+
+      return item;
+    }
   
     /**
      * Determines the drag action type based on the drop target
@@ -74,25 +98,23 @@ export class HowToBeAHeroDragDropHandler {
       }
     
       const actionConfig = this._getDragActionType(event.target);
-    
+
       switch(actionConfig.action) {
         case "favorite":
           // Handle favorite drops
-          const itemId = data.uuid.split('.').pop();
-          const item = this.actor.items.get(itemId);
-          if (!item) return false;
-    
+          const favItem = await this._resolveDroppedItem(data);
+          if (!favItem) return false;
+
           return this.sheet._onDropFavorite(event, {
             type: "item",
-            id: itemId
+            id: favItem.id
           });
-    
+
         case "headerSlot":
           // Handle header slot drops
-          if (data.type !== "Item") return false;
-          const droppedItem = await Item.implementation.fromDropData(data);
+          const droppedItem = await this._resolveDroppedItem(data);
           if (!droppedItem) return false;
-    
+
           // Validate item type based on slot
           if (actionConfig.type === "skill" && !["knowledge", "social", "action"].includes(droppedItem.type)) {
             ui.notifications.warn(game.i18n.localize("HTBAH.WarningOnlySkillsAllowed"));
@@ -106,7 +128,7 @@ export class HowToBeAHeroDragDropHandler {
     
           // Update the header slot
           return this.sheet._setHeaderItem(actionConfig.type, droppedItem.id);
-    
+
         default:
           return false;
       }


### PR DESCRIPTION
## Summary
- add localization strings for drag and drop warning messages

## Testing
- `npm test` *(fails: Missing script)*