### PR TITLE
Fix drag and drop for skills

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -137,6 +137,10 @@
   "HTBAH.Effects": "Effekte",
   "HTBAH.EffectsApplyTokens": "Auf ausgewählte Token anwenden",
   "HTBAH.EffectApplyWarningOwnership": "Effekte können nicht auf Token angewendet werden, deren Besitzer Sie nicht sind.",
+  "HTBAH.WarningOnlySkillsAllowed": "Hier dürfen nur Talente abgelegt werden.",
+  "HTBAH.WarningOnlyWeaponsAllowed": "Hier dürfen nur Waffen abgelegt werden.",
+  "HTBAH.WarningWrongSkillSet": "Dieses Talent gehört zu einer anderen Kategorie.",
+  "HTBAH.WarningSkillNotOwned": "Füge das Talent zuerst dem Charakter hinzu, bevor du es hier benutzt.",
   "HTBAH.EffectsSearch": "Effekte durchsuchen",
 
   "HTBAH.EffectCreate": "Effekt erstellen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -140,6 +140,10 @@
   "HTBAH.Effects": "Effects",
   "HTBAH.EffectsApplyTokens": "Apply to selected tokens",
   "HTBAH.EffectApplyWarningOwnership": "Effects cannot be applied to tokens you are not the owner of.",
+  "HTBAH.WarningOnlySkillsAllowed": "Only skills can be placed here.",
+  "HTBAH.WarningOnlyWeaponsAllowed": "Only weapons can be placed here.",
+  "HTBAH.WarningWrongSkillSet": "Drop the skill onto the correct skill set.",
+  "HTBAH.WarningSkillNotOwned": "Add the skill to the actor before using it here.",
   "HTBAH.EffectsSearch": "Search effects",
   
   "HTBAH.EffectCreate": "Create Effect",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1060,7 +1060,7 @@ async _onUseFavorite(event) {
       }
     });
 
-    html.find('.favorites, .header-stat-column').each((i, zone) => {
+    html.find('.favorites, .header-stat-column, .talent-category').each((i, zone) => {
       zone.addEventListener('dragover', this.dragDropHandler.onDragOver.bind(this.dragDropHandler));
       zone.addEventListener('drop', this.dragDropHandler.onDrop.bind(this.dragDropHandler));
     });

--- a/templates/actor/tabs/character-details.hbs
+++ b/templates/actor/tabs/character-details.hbs
@@ -20,7 +20,7 @@
 {{/inline}}
 
 {{#*inline "talent-category"}}
-    <div class="talent-category flexcol">
+    <div class="talent-category flexcol" data-skill-type="{{categoryType}}">
         <filigree-box class="talents header" filigree-type="typeTalentsHeader">
             <div class="header-content flexrow">
                 <h3 class="flex3">
@@ -68,12 +68,12 @@
 
 <div class="talents-container flexrow">
     <div class="center flex1">
-        {{> talent-category title="Action" talentRows=talentRows.action items=action}}
+        {{> talent-category title="Action" talentRows=talentRows.action items=action categoryType="action"}}
     </div>
     <div class="left flex1">
-        {{> talent-category title="Knowledge" talentRows=talentRows.knowledge items=knowledge}}
+        {{> talent-category title="Knowledge" talentRows=talentRows.knowledge items=knowledge categoryType="knowledge"}}
     </div>
     <div class="right flex1">
-        {{> talent-category title="Social" talentRows=talentRows.social items=social}}
+        {{> talent-category title="Social" talentRows=talentRows.social items=social categoryType="social"}}
     </div>
 </div>


### PR DESCRIPTION
## Summary
- handle drag and drop for skills
- mark skill lists with data attributes so drag drop can detect them
- support dropping new skills into the right skill set
- warn if dropping wrong items or unowned skills
- add German and English localization strings

## Testing
- `npm test` *(fails: Missing script)*